### PR TITLE
Fixing cronjob minutes to *

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,5 +14,5 @@
     "automerge": true
   },
   "timezone": "Etc/UTC",
-  "schedule": ["30 4 */3 * *"]
+  "schedule": ["* 0-5 */3 * *"]
 }


### PR DESCRIPTION
Because it is required by renovate: https://docs.renovatebot.com/key-concepts/scheduling/#scheduling-syntax