### PR TITLE
ci: bump osv workflows to fail-closed fixability gate

### DIFF
--- a/.github/workflows/osv.yml
+++ b/.github/workflows/osv.yml
@@ -14,4 +14,4 @@ permissions:
   contents: read
 jobs:
   scan-pr:
-    uses: "bl4ko/shared-actions/.github/workflows/osv.yml@142ae501528b0f8736a7d948d85d6e9503b20a95" # main
+    uses: "bl4ko/shared-actions/.github/workflows/osv.yml@952d56a5addb1bd02d3f1f28b2e1a3bac7c5451f" # main

--- a/.github/workflows/osv_image.yml
+++ b/.github/workflows/osv_image.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 jobs:
   osv_scan_image:
-    uses: bl4ko/shared-actions/.github/workflows/osv_image.yml@142ae501528b0f8736a7d948d85d6e9503b20a95 # main
+    uses: bl4ko/shared-actions/.github/workflows/osv_image.yml@952d56a5addb1bd02d3f1f28b2e1a3bac7c5451f # main
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Bumps the `scan-pr` and `osv_scan_image` shared-workflow pins from the initial gate (`142ae50`) to the hardened version (`952d56a`) that fails closed on scanner errors and unknown-severity fixable vulns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)